### PR TITLE
feat(commit): add abitity to include body and footer

### DIFF
--- a/lua/telescope/_extensions/conventional_commits/picker.lua
+++ b/lua/telescope/_extensions/conventional_commits/picker.lua
@@ -9,28 +9,30 @@ local cc_types = require("telescope._extensions.conventional_commits.types")
 local picker = function(opts)
     opts = opts or {}
 
-    pickers.new(opts, {
-        prompt_title = "Conventional Commits",
-        finder = finders.new_table({
-            results = cc_types,
-            entry_maker = function(entry)
-                return {
-                    value = entry.value,
-                    display = string.format("%-10s %s", entry.value, entry.description),
-                    ordinal = entry.value,
-                }
+    pickers
+        .new(opts, {
+            prompt_title = "Conventional Commits",
+            finder = finders.new_table({
+                results = cc_types,
+                entry_maker = function(entry)
+                    return {
+                        value = entry.value,
+                        display = string.format("%-10s %s", entry.value, entry.description),
+                        ordinal = entry.value,
+                    }
+                end,
+            }),
+            sorter = conf.generic_sorter(opts),
+            attach_mappings = function(prompt_bufnr, map)
+                actions.select_default:replace(function()
+                    local entry = actions_state.get_selected_entry()
+                    actions.close(prompt_bufnr)
+                    opts.action(entry, opts.include_body_and_footer)
+                end)
+                return true
             end,
-        }),
-        sorter = conf.generic_sorter(opts),
-        attach_mappings = function(prompt_bufnr, map)
-            actions.select_default:replace(function()
-                local entry = actions_state.get_selected_entry()
-                actions.close(prompt_bufnr)
-                opts.action(entry)
-            end)
-            return true
-        end,
-    }):find()
+        })
+        :find()
 end
 
 return picker

--- a/lua/telescope/_extensions/conventional_commits/utils/format_commit_message.lua
+++ b/lua/telescope/_extensions/conventional_commits/utils/format_commit_message.lua
@@ -1,0 +1,14 @@
+return function(initial_message, inputs)
+    local scope = inputs.scope
+    local msg = inputs.msg
+
+    local commit_message = initial_message
+
+    if scope ~= nil and scope ~= "" then
+        commit_message = commit_message .. string.format("(%s)", scope)
+    end
+
+    commit_message = string.format("%s: %s", commit_message, msg)
+
+    return commit_message
+end

--- a/lua/telescope/_extensions/conventional_commits/utils/input.lua
+++ b/lua/telescope/_extensions/conventional_commits/utils/input.lua
@@ -1,0 +1,5 @@
+return function(prompt, key, inputs)
+    vim.ui.input({ prompt = prompt }, function(msg)
+        inputs[key] = msg
+    end)
+end


### PR DESCRIPTION
Hey, first of all, thanks for your work on this plugin. I recently started using it, and I really like it. 

I frequently use the body and footer of commit messages to reference tickets and add some important information. So I created this PR to address those needs and hope to have feedback from you. Any issues or improvements, let me know and I'll address them.

