### PR TITLE
Fix dressing.nvim broken integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ telescope.setup({
                 --     value = feat"
                 -- }
                 vim.print(entry)
-            include_body_and_footer = true, -- Add prompts for commit body and footer
             end,
+            include_body_and_footer = true, -- Add prompts for commit body and footer
         },
     },
 })

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ telescope.setup({
     ...
     extensions = {
         conventional_commits = {
+            theme = "ivy", -- custom theme
             action = function(entry)
                 -- entry = {
                 --     display = "feat       A new feature",

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Plug 'olacin/telescope-cc.nvim'
 
 # packer
 use 'olacin/telescope-cc.nvim'
+
+# lazy.nvim
+{ "olacin/telescope-cc.nvim" }
 ```
 
 ## Usage
@@ -41,7 +44,8 @@ telescope.setup({
                 --     ordinal = "feat",
                 --     value = feat"
                 -- }
-                print(vim.inspect(entry))
+                vim.print(entry)
+            include_body_and_footer = true, -- Add prompts for commit body and footer
             end,
         },
     },
@@ -52,75 +56,25 @@ telescope.load_extension("conventional_commits")
 
 ### Default action
 
-```lua
-local cc_actions = {}
-
-cc_actions.commit = function(t, inputs)
-    local body = inputs.body or ""
-    local footer = inputs.footer or ""
-
-    local cmd = ""
-
-    local commit_message = format_commit_message(t, inputs)
-
-    if vim.g.loaded_fugitive then
-        cmd = string.format(':G commit -m "%s"', commit_message)
-    else
-        print(commit_message)
-        cmd = string.format(':!git commit -m "%s"', commit_message)
-    end
-
-    if body ~= nil and body ~= "" then
-        cmd = cmd .. string.format(' -m "%s"', body)
-    end
-
-    if footer ~= nil and footer ~= "" then
-        cmd = cmd .. string.format(' -m "%s"', footer)
-    end
-
-    print(cmd)
-
-    vim.cmd(cmd)
-end
-
-cc_actions.prompt = function(entry, include_extra_steps)
-    local inputs = {}
-
-    input("Is there a scope ? (optional) ", "scope", inputs)
-
-    input("Enter commit message: ", "msg", inputs)
-
-    if not inputs.msg then
-        return
-    end
-
-    if not include_extra_steps then
-        cc_actions.commit(entry.value, inputs)
-        return
-    end
-
-    input("Enter the commit body: ", "body", inputs)
-
-    input("Enter the commit footer: ", "footer", inputs)
-
-    cc_actions.commit(entry.value, inputs)
-end
-```
+Default action is `cc_actions.commit` and can be found [here](https://github.com/olacin/telescope-cc.nvim/blob/main/lua/telescope/_extensions/conventional_commits/actions.lua).
 
 ### Include body and footer
 
-You can create a command to initiate the extension with the `include_body_and_footer` flag.
+The easiest way is to add `include_body_and_footer` within telescope setup like shown above.
+
+If however you wish to do something more advanced, you can create a command to initiate the extension with the `include_body_and_footer` flag.
 
 ```lua
 local function create_conventional_commit()
-    local actions =
-        require("telescope._extensions.conventional_commits.actions")
-    local picker =
-        require("telescope._extensions.conventional_commits.picker")
+    local actions = require("telescope._extensions.conventional_commits.actions")
+    local picker = require("telescope._extensions.conventional_commits.picker")
+    local themes = require("telescope.themes")
 
+    -- if you use the picker directly you have to provide your theme manually
     picker({
         action = actions.prompt,
         include_body_and_footer = true,
+        -- theme = themes["get_ivy"]() -- ivy theme
     })
 end
 
@@ -130,21 +84,4 @@ vim.keymap.set(
   create_conventional_commit,
   { desc = "Create conventional commit" }
 )
-```
-
-Or you can setup the extension with `include_body_and_footer` flag included globally.
-
-```lua
-local actions =
-    require("telescope._extensions.conventional_commits.actions")
-
-telescope.setup({
-    ...
-    extensions = {
-        conventional_commits = {
-            action = actions.prompt,
-            include_body_and_footer = true,
-        },
-    },
-})
 ```

--- a/lua/telescope/_extensions/conventional_commits.lua
+++ b/lua/telescope/_extensions/conventional_commits.lua
@@ -5,23 +5,42 @@ end
 
 local cc_actions = require("telescope._extensions.conventional_commits.actions")
 local cc_picker = require("telescope._extensions.conventional_commits.picker")
-local cc_types = require("telescope._extensions.conventional_commits.types")
+local themes = require("telescope.themes")
 
 local action = cc_actions.prompt
+local include_body_and_footer = false
+local theme = {}
 
 local search = function(opts)
     opts = opts or {}
 
-    defaults = {
+    local defaults = {
         action = action,
+        include_body_and_footer = include_body_and_footer,
     }
 
-    cc_picker(vim.tbl_extend("force", defaults, opts))
+    opts = vim.tbl_extend("force", defaults, opts)
+    opts = vim.tbl_extend("force", defaults, theme)
+
+    cc_picker(opts)
 end
 
 return telescope.register_extension({
     setup = function(cfg)
         action = cfg.action or cc_actions.prompt
+        include_body_and_footer = cfg.include_body_and_footer or false
+
+        if cfg.theme and cfg.theme ~= "" then
+            if not themes["get_" .. cfg.theme] then
+                vim.notify(
+                    string.format("Could not apply provided telescope theme: '%s'", cfg.theme),
+                    vim.log.levels.WARN,
+                    { title = "telescope-cc.nvim" }
+                )
+            else
+                theme = themes["get_" .. cfg.theme]()
+            end
+        end
     end,
     exports = {
         conventional_commits = search,

--- a/lua/telescope/_extensions/conventional_commits/utils/input.lua
+++ b/lua/telescope/_extensions/conventional_commits/utils/input.lua
@@ -1,5 +1,0 @@
-return function(prompt, key, inputs)
-    vim.ui.input({ prompt = prompt }, function(msg)
-        inputs[key] = msg
-    end)
-end


### PR DESCRIPTION
[dressing.nvim](https://github.com/stevearc/dressing.nvim) replacement of core's `vim.ui.input` makes it asynchronous, which is not the case for the standard `vim.ui.input`.

By cascading the callbacks within the `prompt` action, prompts are executed in a synchronous way and fixes #5.