### PR TITLE
Add an healthcheck

### DIFF
--- a/lua/telescope/_extensions/conventional_commits.lua
+++ b/lua/telescope/_extensions/conventional_commits.lua
@@ -45,4 +45,23 @@ return telescope.register_extension({
     exports = {
         conventional_commits = search,
     },
+    health = function()
+        local ok = vim.health.ok or vim.health.report_ok
+        local warn = vim.health.warn or vim.health.report_warn
+        local error = vim.health.error or vim.health.report_error
+
+        -- check for git installation
+        if vim.fn.executable("git") == 0 then
+            error("git is not installed")
+        else
+            ok("git is installed")
+        end
+
+        -- check for fugitive installation
+        if vim.g.loaded_fugitive == nil then
+            warn("fugitive.vim is not loaded")
+        else
+            ok("fugitive.vim is loaded")
+        end
+    end,
 })


### PR DESCRIPTION
This PR is adding an healthcheck for the extension that checks if:
- `git` is installed
- [`fugitive.vim`](https://github.com/tpope/vim-fugitive) is loaded (optional integration that is used when available)

Health checks can be run through `:checkhealth telescope` and show the following output:
```
==============================================================================
telescope: require("telescope.health").check()

Checking for required plugins ~
- OK plenary installed.
- OK nvim-treesitter installed.

Checking external dependencies ~
- OK rg: found ripgrep 14.0.3
- OK fd: found fd 9.0.0

===== Installed extensions ===== ~

Telescope Extension: `conventional_commits` ~
- OK git is installed
- OK fugitive.vim is loaded
```